### PR TITLE
Fix no selector crash 

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -180,7 +180,7 @@ Parser.parse = function (source) {
 
         // Check for property
         var propertyMatch = line.trim().match(/^([a-zA-Z-]+):\s+(.*)$/i)
-        if (propertyMatch) {
+        if (currentRuleset && propertyMatch) {
           currentRuleset.properties.push({
             type: 'property',
             position: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "9e-sass-lint",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Makes sure you stick to our CSS rule order http://9elements.com/css-rule-order/",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixed an issue that crashes atom if you delete a selector and there is no current ruleset (mostly a first line selector).
